### PR TITLE
FOGL-4741: do not show removed instances in GET API

### DIFF
--- a/C/services/common/include/notification_manager.h
+++ b/C/services/common/include/notification_manager.h
@@ -188,7 +188,7 @@ class NotificationInstance
 		{
 			return (m_delivery ? m_delivery->getPlugin() : NULL);
 		};
-		std::string		toJSON();
+		std::string		toJSON(bool showAll = false);
 		bool			isEnabled() const { return m_enable; };
 		NotificationType	getType() const { return m_type; };
 		std::string		getTypeString(NotificationType type);
@@ -240,7 +240,7 @@ class NotificationManager
 		const std::string&	getName() const { return m_name; };
 		static NotificationManager*
 					getInstance();
-		std::string		getJSONInstances();
+		std::string		getJSONInstances(bool showAll = false);
 		void 			loadInstances();
 		std::map<std::string, NotificationInstance *>&
 					getInstances() { return m_instances; };

--- a/C/services/common/notification_api.cpp
+++ b/C/services/common/notification_api.cpp
@@ -438,11 +438,22 @@ void NotificationApi::getNotificationObject(NOTIFICATION_OBJECT object,
 			break;
 
 		case ObjGetNotificationsAll:
-			// Get all Notifications
+			{
+			// Get Notifications
+			auto query = request->parse_query_string();
+			auto search = query.find("all");
+
+			// Fetch active notifications
+			// GET /notification
+			//
+			// Fetch active notifications plus ones still in the zombie state
+			// GET /notification?all
+			// false parameter in getJSONInstances means: show only active notifications
 			responsePayload = "{ \"notifications\": [" + \
-					  manager->getJSONInstances()  + \
+					  manager->getJSONInstances(search != query.end())  + \
 					  "] }";
 			break;
+			}
 
 		case ObjCreateNotification:
 			{

--- a/C/services/common/notification_manager.cpp
+++ b/C/services/common/notification_manager.cpp
@@ -196,12 +196,17 @@ NotificationInstance::~NotificationInstance()
  *
  * @return	A JSON string representation of the instance
  */
-string NotificationInstance::toJSON()
+string NotificationInstance::toJSON(bool showAll)
 {
 	ostringstream ret;
 
 	ret << "{\"name\": \"" << this->getName() << "\", \"enable\": ";
 	ret << (this->isEnabled() ? "true" : "false") << ", ";
+	if (showAll)
+	{
+		ret << "\"active\": ";
+		ret << (!this->isZombie() ? "true" : "false") << ", ";
+	}
 	ret << "\"type\": \"" << this->getTypeString(this->getType()) << "\", ";
 	ret << "\"rule\": \"";
 	ret << (this->getRulePlugin() ? this->getRulePlugin()->getName() : "");
@@ -381,11 +386,21 @@ string NotificationManager::getJSONInstances()
 		  it != m_instances.end();
 		  ++it)
 	{
-		// Get instance JSON string
-		ret += (it->second)->toJSON();
-		if (std::next(it) != m_instances.end())
+		// Do not show Zombie instance
+		if (showAll == true || !it->second->isZombie())
 		{
-			ret += ", ";
+			// Get instance JSON string
+			ret += (it->second)->toJSON(showAll);
+		}
+
+		// Add ', ' separator
+		if (ret[0] != '\0' &&
+		   std::next(it) != m_instances.end())
+		{
+			if (showAll == true || !std::next(it)->second->isZombie())
+			{
+				ret += ", ";
+			}
 		}
 	}
 	return ret;


### PR DESCRIPTION
Query parameter ?all allows to show all instances with "active" property, which is false for removed instances (in Zombie state)