### PR TITLE
FOGL-5557 Make retrigger time >= rather than > in order to allow 0 to…

### DIFF
--- a/C/services/common/notification_manager.cpp
+++ b/C/services/common/notification_manager.cpp
@@ -679,7 +679,7 @@ bool NotificationInstance::handleState(bool evalRet)
 		else
 		{
 			// Try sending "triggered" when evaluation is true
-			ret = evalRet && (diffTime > nType.retriggerTime);
+			ret = evalRet && (diffTime >= nType.retriggerTime);
 			// Here state change depends on sending value
 			setTriggered = ret;
 		}
@@ -689,7 +689,7 @@ bool NotificationInstance::handleState(bool evalRet)
 		// Set state depends on evalRet
 		setTriggered = evalRet;
 		// Try sending "triggered" when evaluation is true
-		ret = evalRet && diffTime > nType.retriggerTime;
+		ret = evalRet && diffTime >= nType.retriggerTime;
 		break;
 
 	default:


### PR DESCRIPTION
… mean always trigger.

Signed-off-by: Mark Riddoch <mark@dianomic.com>