### PR TITLE
FOGL-8642: Store management client handle so that service registry may be accessed

### DIFF
--- a/C/services/notification/notification_service.cpp
+++ b/C/services/notification/notification_service.cpp
@@ -260,6 +260,7 @@ bool NotificationService::start(string& coreAddress,
 				    storageInfo.getPort());
 	m_storage = &storageClient;
 
+	m_storage->registerManagement(m_mgtClient);
 
 	// Setup NotificationManager class
 	NotificationManager instances(m_name, m_mgtClient, this);


### PR DESCRIPTION
Store management client handle so that service registry may be accessed to detect storage service unavailability subsequently, if required.

m_management is used in StorageClient::handleException() routine to detect whether storage service has failed.