### PR TITLE
FOGL-9770 Only set min log level after we have created the logger

### DIFF
--- a/C/services/notification/notification.cpp
+++ b/C/services/notification/notification.cpp
@@ -122,10 +122,9 @@ int main(int argc, char *argv[])
 	std::signal(SIGSTOP, signalHandler);
 	std::signal(SIGTERM, signalHandler);
 
-	Logger::getLogger()->setMinLevel(logLevel);
-
 	// Instantiate the NotificationService class
 	service = new NotificationService(myName, token);
+	Logger::getLogger()->setMinLevel(logLevel);
 	if (dryrun)
 	{
 		service->setDryRun();


### PR DESCRIPTION
Fixes an issue that a Logger class is created to set the minimum log level and then the service creates a new one which does not inherit that original one.